### PR TITLE
Update packer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,7 @@ Install [{packer}](https://github.com/JohnCoene/packer) (see packer's [documenta
 Install nodes modules with:
 
 ```r
-packer::npm_install("proportions-chart", scope = "prod")
-```
-
-Update dependencies with:
-
-```r
-packer::npm_update()
+packer::npm_install()
 ```
 
 Modify `srcjs/widgets/bar.js`, then run:


### PR DESCRIPTION
This is just a small change to the instructions in the README.

The dependencies required to bundle JavaScript are included in the `package.json` file (in a sense, a bit like the `DESCRIPTION` of an R package).
Therefore anyone who clones the package can just run `packer::npm_install()`: when no arguments are passed it run `npm install` which will install the dependencies found in `package.json` which is a like `devtools::install_deps()`.

Note that to make it easier to contribute, I've also added some helper functions [documented here](https://packer.john-coene.com/#/guide/rec) 